### PR TITLE
Check also for Users as registry alias (task #3408)

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -11,7 +11,12 @@ EventManager::instance()->on(
     'Model.afterSaveCommit',
     // Link newly created users to default group
     function (Event $event, $entity) {
-        if ('CakeDC/Users.Users' === $event->subject()->registryAlias()) {
+        $usersTable = Configure::read('Auth.authenticate.all.userModel');
+        $usersTable = array_merge(['CakeDC/Users.Users'], [$usersTable]);
+        if (!in_array($event->subject()->registryAlias(), $usersTable)) {
+            return;
+        }
+
             // get default group name
             $defaultGroupName = Configure::read('Groups.defaultGroup');
             if (!$defaultGroupName) {
@@ -31,6 +36,5 @@ EventManager::instance()->on(
             $user = $table->Users->get($entity->id);
 
             $table->Users->link($group, [$user]);
-        }
     }
 );

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -17,24 +17,24 @@ EventManager::instance()->on(
             return;
         }
 
-            // get default group name
-            $defaultGroupName = Configure::read('Groups.defaultGroup');
-            if (!$defaultGroupName) {
-                return;
-            }
-            $table = TableRegistry::get('Groups.Groups');
-            // get default group entity
-            $group = $table->findByName($defaultGroupName)->first();
+        // get default group name
+        $defaultGroupName = Configure::read('Groups.defaultGroup');
+        if (!$defaultGroupName) {
+            return;
+        }
+        $table = TableRegistry::get('Groups.Groups');
+        // get default group entity
+        $group = $table->findByName($defaultGroupName)->first();
 
-            // skip if default group is not found
-            if (!$group) {
-                return;
-            }
+        // skip if default group is not found
+        if (!$group) {
+            return;
+        }
 
-            // need to re-fetch the user entity from the database
-            // as is still considered as new and link() fails.
-            $user = $table->Users->get($entity->id);
+        // need to re-fetch the user entity from the database
+        // as is still considered as new and link() fails.
+        $user = $table->Users->get($entity->id);
 
-            $table->Users->link($group, [$user]);
+        $table->Users->link($group, [$user]);
     }
 );


### PR DESCRIPTION
This PR handles cases where the default `CakeDC Users` plugin table is overwritten in the plugin's configuration, as shown [here](https://github.com/CakeDC/users/blob/master/Docs/Documentation/Extending-the-Plugin.md#extending-the-model-tableentity).