### PR TITLE
Bugfix duplicated users (task #3257)

### DIFF
--- a/src/Controller/GroupsController.php
+++ b/src/Controller/GroupsController.php
@@ -18,7 +18,16 @@ class GroupsController extends AppController
      */
     public function index()
     {
-        $this->set('groups', $this->paginate($this->Groups, ['contain' => 'Users', 'maxLimit' => 500, 'limit' => 500]));
+        $this->set('groups', $this->paginate($this->Groups, [
+            'contain' => [
+                'Users' => function ($q) {
+                    return $q->select(['Users.id', 'Users.username'])
+                        ->order(['Users.username' => 'ASC']);
+                }
+            ],
+            'maxLimit' => 500,
+            'limit' => 500
+        ]));
         $this->set('_serialize', ['groups']);
     }
 
@@ -32,8 +41,11 @@ class GroupsController extends AppController
     public function view($id = null)
     {
         $group = $this->Groups->get($id, [
-            'contain' => ['Users']
+            'contain' => ['Users' => function ($q) {
+                return $q->select(['Users.id', 'Users.username', 'Users.first_name', 'Users.last_name']);
+            }]
         ]);
+
         $this->set('group', $group);
         $this->set('_serialize', ['group']);
     }

--- a/src/Shell/GroupShell.php
+++ b/src/Shell/GroupShell.php
@@ -11,7 +11,8 @@ class GroupShell extends Shell
      */
     public $tasks = [
         'Groups.Assign',
-        'Groups.Import'
+        'Groups.Import',
+        'Groups.UserGroupCleanup'
     ];
 
     /**
@@ -30,6 +31,10 @@ class GroupShell extends Shell
             ->addSubcommand(
                 'import',
                 ['help' => 'Import system groups.', 'parser' => $this->Import->getOptionParser()]
+            )
+            ->addSubcommand(
+                'user_group_cleanup',
+                ['help' => 'User group clean up.', 'parser' => $this->UserGroupCleanup->getOptionParser()]
             );
 
         return $parser;

--- a/src/Shell/Task/UserGroupCleanupTask.php
+++ b/src/Shell/Task/UserGroupCleanupTask.php
@@ -1,0 +1,72 @@
+<?php
+namespace Groups\Shell\Task;
+
+use Cake\Console\Shell;
+use Cake\Core\Configure;
+use Cake\ORM\Entity;
+use Cake\ORM\Table;
+use Cake\ORM\TableRegistry;
+
+/**
+ * Task for assign default group to all users.
+ */
+class UserGroupCleanupTask extends Shell
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function main()
+    {
+        $this->out('Task: user group cleanup');
+        $this->hr();
+
+        // get groups table
+        $table = TableRegistry::get('Groups.Groups');
+        $query = $table->find('all');
+
+        if ($query->isEmpty()) {
+            $this->abort('No groups found.');
+        }
+
+        $groups = $query->all();
+        foreach ($groups as $group) {
+            $this->info('Cleaning up ' . $group->name . ' group ..');
+
+            $table = TableRegistry::get('groups_users');
+            $query = $table->find('all')
+                ->where(['group_id' => $group->id])
+                ->select(['user_id'])
+                ->distinct(['user_id']);
+
+            if ($query->isEmpty()) {
+                continue;
+            }
+
+            $users = $query->all();
+            $count = 0;
+            foreach ($users as $user) {
+                $query = $table->find('all')
+                    ->where(['user_id' => $user->user_id, 'group_id' => $group->id]);
+
+                if ($query->count() < 2) {
+                    continue;
+                }
+
+                $count += $query->count() - 1;
+
+                $result = $query->toArray();
+
+                $entity = array_pop($result);
+
+                $query = $table->query();
+                $query->delete()
+                    ->where(['user_id' => $entity->user_id, 'group_id' => $entity->group_id, 'id !=' => $entity->id])
+                    ->execute();
+            }
+
+            $this->info('Deleted ' . $count . ' records ..');
+        }
+
+        $this->out('<success>User group cleanup task completed</success>');
+    }
+}

--- a/src/Template/Groups/index.ctp
+++ b/src/Template/Groups/index.ctp
@@ -57,7 +57,6 @@ echo $this->Html->scriptBlock(
                                 foreach ($group->users as $user) {
                                     $users[] = $this->Html->link($user->username, '/users/view/' . $user->id, ['class' => "label label-primary"]);
                                 }
-                                sort($users);
                                 print implode(' ', $users);
                             }
                             ?>


### PR DESCRIPTION
This is a temporary fix for duplicated user entries in groups.

You can run this shell as follows:
`bin/cake group user_group_cleanup`