### PR TITLE
Composer update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,7 @@
     "type": "cakephp-plugin",
     "license": "GPL-2.0",
     "require": {
-        "qobo/cakephp-utils": "^5.0",
-        "cakedc/users": "^4.0"
+        "qobo/cakephp-utils": "^5.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.0",


### PR DESCRIPTION
Removed `cakedc/users` from composer requirements as it is already
required by `qobo/cakephp-utils`.