### PR TITLE
Adding getUserGroupsAll method to return objects (issue #66)

### DIFF
--- a/src/Model/Table/GroupsTable.php
+++ b/src/Model/Table/GroupsTable.php
@@ -100,7 +100,7 @@ class GroupsTable extends Table
     }
 
     /**
-     * Method that retrieves specified user's groups.
+     * Method that retrieves specified user's groups as list.
      *
      * @param string $userId user id
      * @param array $options Query options
@@ -112,6 +112,25 @@ class GroupsTable extends Table
             'keyField' => 'id',
             'valueField' => 'name'
         ]);
+        $query->matching('Users', function ($q) use ($userId) {
+            return $q->where(['Users.id' => $userId]);
+        });
+        $query->applyOptions($options);
+
+        return $query->toArray();
+    }
+
+    /**
+     * Method that retrieves specified user's groups.
+     *
+     * @param string $userId user id
+     * @param array $options Query options
+     * @return array
+     */
+    public function getUserGroupsAll($userId, array $options = [])
+    {
+        $query = $this->find('all');
+
         $query->matching('Users', function ($q) use ($userId) {
             return $q->where(['Users.id' => $userId]);
         });

--- a/tests/TestCase/Model/Table/GroupsTableTest.php
+++ b/tests/TestCase/Model/Table/GroupsTableTest.php
@@ -18,6 +18,8 @@ class GroupsTableTest extends TestCase
      */
     public $fixtures = [
         'plugin.groups.groups',
+        'plugin.groups.users',
+        'plugin.groups.groups_users',
     ];
 
     /**
@@ -80,5 +82,28 @@ class GroupsTableTest extends TestCase
         $result = $this->Groups->save($entity);
 
         $this->assertNotEmpty($result->get('id'));
+    }
+
+    public function testGetUserGroups()
+    {
+        $userId = '00000000-0000-0000-0000-000000000001';
+        $result = $this->Groups->getUserGroups($userId);
+        $values = array_values($result);
+
+        $this->assertTrue(is_array($result));
+        $this->assertNotEmpty($result);
+        $this->assertTrue(!is_object($values[0]));
+    }
+
+    public function testGetUserGroupsAll()
+    {
+        $userId = '00000000-0000-0000-0000-000000000001';
+
+        $result = $this->Groups->getUserGroupsAll($userId);
+        $values = array_values($result);
+
+        $this->assertNotEmpty($result);
+        $this->assertTrue(is_array($result));
+        $this->assertTrue(is_object($values[0]));
     }
 }


### PR DESCRIPTION
To avoid breaking any of the existing app's logic of the issue #66 , we add extra method `getUserGroupsAll()` to return an array of group instances.