### PR TITLE
CakePHP 3.6 support and PHPStan (task #8244)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,3 +16,6 @@ end_of_line = crlf
 [*.yml]
 indent_style = space
 indent_size = 2
+
+[*.twig]
+insert_final_newline = false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,52 @@
+# Define the line ending behavior of the different file extensions
+# Set default behaviour, in case users don't have core.autocrlf set.
+* text=auto
+* text eol=lf
+
+# Explicitly declare text files we want to always be normalized and converted
+# to native line endings on checkout.
+.htaccess text
+*.css text diff=css
+*.ctp text diff=php
+*.default text
+*.html text diff=html
+*.ini text
+*.js text
+*.md text
+*.php text diff=php
+*.po text
+*.properties text
+*.sql text
+*.svg text
+*.txt text
+*.xml text
+*.yml text
+
+# Declare files that will always have CRLF line endings on checkout.
+*.bat eol=crlf
+
+# Declare files that will always have LF line endings on checkout.
+*.pem eol=lf
+
+# Denote all files that are truly binary and should not be modified.
+composer binary
+*.png binary
+*.jpg binary
+*.gif binary
+*.ico binary
+*.mo binary
+*.pdf binary
+*.phar binary
+
+# Web fonts are binary
+*.otf binary
+*.eot binary
+*.ttf binary
+*.woff binary
+*.woff2 binary
+
+# Treat zip files as binary
+*.7z binary
+*.bz2 binary
+*.gz binary
+*.zip binary

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,41 @@
+# Project specific files #
+##########################
 build/
 vendor/
+cghooks.lock
+
 composer.lock
 config/Migrations/schema-dump-default.lock
 config/Migrations/schema-dump-test.lock
+# OS generated files #
+######################
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+Icon?
+ehthumbs.db
+Thumbs.db
+
+# Tool specific files #
+#######################
+# vim
+*~
+*.swp
+*.swo
+# sublime text & textmate
+*.sublime-*
+*.stTheme.cache
+*.tmlanguage.cache
+*.tmPreferences.cache
+# Eclipse
+.settings/*
+# JetBrains, aka PHPStorm, IntelliJ IDEA
+.idea/*
+# NetBeans
+nbproject/*
+# Visual Studio Code
+.vscode
+# Sass preprocessor
+.sass-cache/

--- a/.stickler.yml
+++ b/.stickler.yml
@@ -1,6 +1,7 @@
 linters:
   phpcs:
     standard: CakePHP
-    extensions: '.php,.ctp'
+    extensions: 'php,ctp'
+    exclude: 'Generic.Commenting.Todo'
 files:
-  ignore: ['config/*', 'tests/*']
+    ignore: ['webroot/plugins/*']

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,8 @@
-#This Travis config template file was taken from https://github.com/FriendsOfCake/travis
-sudo: true
-dist: trusty
-
 language: php
 
-php:
-  - 7.1
-  - 7.2
-  - nightly
+dist: trusty
+
+sudo: false
 
 cache:
   directories:
@@ -21,8 +16,20 @@ env:
 
 matrix:
   fast_finish: true
+
   allow_failures:
+    - php: 7.3
     - php: nightly
+
+  include:
+    - php: 7.1
+      env: PHPCS=1 COVERAGE=1 PHPSTAN=0
+    - php: 7.2
+      env: PHPCS=1 COVERAGE=0 PHPSTAN=0
+    - php: 7.3
+      env: PHPCS=1 COVERAGE=0 PHPSTAN=0
+    - php: nightly
+      env: PHPCS=1 COVERAGE=0 PHPSTAN=0
 
 before_install:
   - echo "extension=ldap.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
@@ -30,19 +37,21 @@ before_install:
 install:
   - composer validate --strict
   - composer install --no-interaction --no-progress --no-suggest
-  - mkdir -p build/logs
+  - mkdir -p build/test-coverage build/test-results
 
 before_script:
   - sh -c "if [ '$DB' = 'mysql' ]; then mysql -e 'CREATE DATABASE IF NOT EXISTS cakephp_test DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;'; fi"
 
 script:
-  - vendor/bin/phpcs
-  - if [ $TRAVIS_PHP_VERSION != "7.1" ]; then vendor/bin/phpunit --no-coverage; else vendor/bin/phpunit; fi
+  - if [[ $PHPCS = 1 ]]; then ./vendor/bin/phpcs; fi
+  - if [[ $COVERAGE = 0 ]]; then ./vendor/bin/phpunit --no-coverage; fi
+  - if [[ $COVERAGE = 1 ]]; then ./vendor/bin/phpunit; fi
+  - if [[ $PHPSTAN = 1 ]]; then ./vendor/bin/phpstan analyse; fi
 
 after_success:
   - curl -s https://codecov.io/bash > /tmp/codecov.sh
   - chmod +x /tmp/codecov.sh
-  - /tmp/codecov.sh -s build/logs
+  - /tmp/codecov.sh -s build/test-results
 
 notifications:
   email:

--- a/composer.json
+++ b/composer.json
@@ -1,34 +1,58 @@
 {
     "name": "qobo/cakephp-groups",
     "description": "Groups plugin for CakePHP",
+    "keywords": ["cakephp", "groups"],
     "type": "cakephp-plugin",
     "license": "MIT",
-	"authors": [
-		{
-			"name": "Qobo Ltd",
-			"email": "info@qobo.biz",
-			"homepage": "https://www.qobo.biz",
-			"role": "Developer"
-		}
-	],
+    "homepage": "https://www.qobo.biz",
+    "authors": [
+        {
+            "name": "Qobo Ltd",
+            "email": "support@qobo.biz",
+            "homepage": "https://www.qobo.biz",
+            "role": "Developer"
+        }
+    ],
+    "support": {
+        "issues": "https://github.com/QoboLtd/cakephp-groups/issues",
+        "source": "https://github.com/QoboLtd/cakephp-groups"
+    },
+    "config": {
+        "sort-packages": true,
+        "optimize-autoloader": true
+    },
     "require": {
-        "qobo/cakephp-utils": "^9.0"
+        "qobo/cakephp-utils": "^10.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.0",
-        "cakephp/cakephp-codesniffer": "^3.0"
+        "qobo/cakephp-composer-dev": "^v1.0"
     },
     "autoload": {
         "psr-4": {
-            "Groups\\": "src",
-            "CakeDC\\Users\\Test\\Fixture\\": "tests"
+            "Groups\\": "src/"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "Groups\\Test\\": "tests",
-            "CakeDC\\Users\\Test\\": "./vendor/cakedc/users/tests",
-            "Cake\\Test\\": "./vendor/cakephp/cakephp/tests"
+            "Groups\\Test\\": "tests/",
+            "CakeDC\\Users\\Test\\": "vendor/cakedc/users/tests/",
+            "Cake\\Test\\": "vendor/cakephp/cakephp/tests/"
         }
-    }
+    },
+    "scripts": {
+        "test": [
+            "phpcs",
+            "phpunit --no-coverage"
+        ],
+        "test-coverage": [
+            "phpcs",
+            "phpunit"
+        ],
+        "post-autoload-dump": "Cake\\Composer\\Installer\\PluginInstaller::postAutoloadDump"
+    },
+    "scripts-descriptions": {
+        "test": "Runs phpcs and phpunit without coverage",
+        "test-coverage": "Runs phpcs and phpunit with coverage enabled"
+    },
+    "prefer-stable": true
 }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -9,16 +9,15 @@
     <description>PHP CodeSniffer Configuration</description>
 
     <!-- Coding standard to use -->
-    <rule ref="./vendor/cakephp/cakephp-codesniffer/CakePHP" />
+    <rule ref="./vendor/cakephp/cakephp-codesniffer/CakePHP">
+        <exclude name="Generic.Commenting.Todo" />
+    </rule>
 
     <!-- Do not fail on warnings -->
     <config name="ignore_warnings_on_exit" value="1" />
 
     <!-- Assume UTF-8 -->
     <config name="encoding" value="UTF-8" />
-
-    <!-- Extensions to check -->
-    <arg name="extensions" value="php,inc,ctp,js,css" />
 
     <!-- Use colors -->
     <arg name="colors" />
@@ -29,5 +28,12 @@
     <!-- Files and directories to check -->
     <file>./src/</file>
     <file>./tests/</file>
+    <file>./config/</file>
     <file>./webroot/</file>
+
+    <!-- Exclude patterns -->
+    <exclude-pattern>config/Migrations/*</exclude-pattern>
+    <exclude-pattern>config/Seeds/*</exclude-pattern>
+    <exclude-pattern>webroot/plugins/*</exclude-pattern>
+    <exclude-pattern>*\.min\.(css|js)</exclude-pattern>
 </ruleset>

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,14 @@
+parameters:
+    level: 7
+    paths:
+        - src
+        - tests
+        - webroot
+    autoload_files:
+        - tests/bootstrap.php
+    earlyTerminatingMethodCalls:
+        Cake\Console\Shell:
+            - abort
+includes:
+    - vendor/thecodingmachine/phpstan-strict-rules/phpstan-strict-rules.neon
+    - vendor/timeweb/phpstan-enum/extension.neon

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,31 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
-	colors="true"
-	processIsolation="false"
-	stopOnFailure="false"
-	syntaxCheck="false"
-	bootstrap="./tests/bootstrap.php"
+    colors="true"
+    processIsolation="false"
+    stopOnFailure="false"
+    bootstrap="./tests/bootstrap.php"
     verbose="true"
-	>
-	<php>
-		<ini name="memory_limit" value="-1"/>
-		<ini name="apc.enable_cli" value="1"/>
-	</php>
-
-	<filter>
-		<whitelist>
-            <directory suffix=".php">./src/</directory>
-            <directory suffix=".php">./webroot/</directory>
-		</whitelist>
-	</filter>
+    >
+    <php>
+        <ini name="memory_limit" value="-1"/>
+        <ini name="apc.enable_cli" value="1"/>
+    </php>
 
     <logging>
-		<log type="coverage-text" target="php://stdout" showUncoveredFiles="true"/>
-		<log type="coverage-html" target="build/coverage"/>
-		<log type="coverage-clover" target="build/logs/clover.xml"/>
-		<log type="coverage-crap4j" target="build/logs/crap4j.xml"/>
-		<log type="junit" target="build/logs/junit.xml"/>
+        <log type="coverage-text" target="php://stdout" showUncoveredFiles="true"/>
+        <log type="coverage-html" target="build/test-coverage"/>
+        <log type="coverage-clover" target="build/test-results/clover.xml"/>
+        <log type="coverage-crap4j" target="build/test-results/crap4j.xml"/>
+        <log type="junit" target="build/test-results/junit.xml"/>
     </logging>
+
+    <!-- Add any additional test suites you want to run here -->
+    <testsuites>
+        <testsuite name="groups">
+            <directory>tests/TestCase</directory>
+        </testsuite>
+    </testsuites>
 
     <!-- Setup a listener for fixtures -->
     <listeners>
@@ -38,11 +37,11 @@
         </listener>
     </listeners>
 
-    <!-- Add any additional test suites you want to run here -->
-    <testsuites>
-        <testsuite name="Groups Test Suite">
-            <directory>./tests/TestCase</directory>
-        </testsuite>
-    </testsuites>
-
+    <!-- Ignore vendor tests in code coverage reports -->
+    <filter>
+        <whitelist>
+            <directory suffix=".php">./src/</directory>
+            <directory suffix=".php">./webroot/</directory>
+        </whitelist>
+    </filter>
 </phpunit>

--- a/src/Controller/Component/GroupComponent.php
+++ b/src/Controller/Component/GroupComponent.php
@@ -14,6 +14,11 @@ namespace Groups\Controller\Component;
 use Cake\Controller\Component;
 use Cake\ORM\TableRegistry;
 
+/**
+ * Groups Component
+ *
+ * @property \Cake\Controller\Component\AuthComponent $Auth
+ */
 class GroupComponent extends Component
 {
     public $components = ['Auth'];

--- a/src/Controller/Component/GroupComponent.php
+++ b/src/Controller/Component/GroupComponent.php
@@ -31,9 +31,9 @@ class GroupComponent extends Component
     /**
      * Method that retrieves specified user's groups
      * @param  string $userId user id
-     * @return array
+     * @return mixed[]
      */
-    public function getUserGroups($userId = '')
+    public function getUserGroups(string $userId = ''): array
     {
         // if not specified, get current user's id
         if (empty($userId)) {

--- a/src/Controller/GroupsController.php
+++ b/src/Controller/GroupsController.php
@@ -69,7 +69,11 @@ class GroupsController extends AppController
     {
         $group = $this->Groups->newEntity();
         if ($this->request->is('post')) {
-            $group = $this->Groups->patchEntity($group, $this->request->getData());
+            /**
+             * @var array $data
+             */
+            $data = $this->request->getData();
+            $group = $this->Groups->patchEntity($group, $data);
             if ($this->Groups->save($group)) {
                 $this->Flash->success((string)__('The group has been saved.'));
 
@@ -97,7 +101,11 @@ class GroupsController extends AppController
             'contain' => ['Users']
         ]);
         if ($this->request->is(['patch', 'post', 'put'])) {
-            $group = $this->Groups->patchEntity($group, $this->request->getData());
+            /**
+             * @var array $data
+             */
+            $data = $this->request->getData();
+            $group = $this->Groups->patchEntity($group, $data);
             if ($this->Groups->save($group)) {
                 $this->Flash->success((string)__('The group has been saved.'));
 

--- a/src/Controller/GroupsController.php
+++ b/src/Controller/GroupsController.php
@@ -24,7 +24,7 @@ class GroupsController extends AppController
     /**
      * Index method
      *
-     * @return void
+     * @return \Cake\Http\Response|void|null
      */
     public function index()
     {
@@ -45,10 +45,10 @@ class GroupsController extends AppController
      * View method
      *
      * @param string|null $id Group id.
-     * @return void
-     * @throws \Cake\Network\Exception\NotFoundException When record not found.
+     * @return \Cake\Http\Response|void|null
+     * @throws \Cake\Http\Exception\NotFoundException When record not found.
      */
-    public function view($id = null)
+    public function view(string $id = null)
     {
         $group = $this->Groups->get($id, [
             'contain' => ['Users' => function ($q) {
@@ -63,19 +63,19 @@ class GroupsController extends AppController
     /**
      * Add method
      *
-     * @return \Cake\Network\Response|null Redirects on successful add, renders view otherwise.
-     */
+     * @return \Cake\Http\Response|void|null Redirects on successful add, renders view otherwise.
+     * */
     public function add()
     {
         $group = $this->Groups->newEntity();
         if ($this->request->is('post')) {
-            $group = $this->Groups->patchEntity($group, $this->request->data);
+            $group = $this->Groups->patchEntity($group, $this->request->getData());
             if ($this->Groups->save($group)) {
-                $this->Flash->success(__('The group has been saved.'));
+                $this->Flash->success((string)__('The group has been saved.'));
 
                 return $this->redirect(['action' => 'index']);
             } else {
-                $this->Flash->error(__('The group could not be saved. Please, try again.'));
+                $this->Flash->error((string)__('The group could not be saved. Please, try again.'));
             }
         }
         $users = $this->Groups->Users->find('list', ['limit' => 500]);
@@ -88,22 +88,22 @@ class GroupsController extends AppController
      * Edit method
      *
      * @param string|null $id Group id.
-     * @return \Cake\Network\Response|null Redirects on successful edit, renders view otherwise.
-     * @throws \Cake\Network\Exception\NotFoundException When record not found.
+     * @return \Cake\Http\Response|void|null Redirects on successful edit, renders view otherwise.
+     * @throws \Cake\Http\Exception\NotFoundException When record not found.
      */
-    public function edit($id = null)
+    public function edit(string $id = null)
     {
         $group = $this->Groups->get($id, [
             'contain' => ['Users']
         ]);
         if ($this->request->is(['patch', 'post', 'put'])) {
-            $group = $this->Groups->patchEntity($group, $this->request->data);
+            $group = $this->Groups->patchEntity($group, $this->request->getData());
             if ($this->Groups->save($group)) {
-                $this->Flash->success(__('The group has been saved.'));
+                $this->Flash->success((string)__('The group has been saved.'));
 
                 return $this->redirect(['action' => 'index']);
             } else {
-                $this->Flash->error(__('The group could not be saved. Please, try again.'));
+                $this->Flash->error((string)__('The group could not be saved. Please, try again.'));
             }
         }
         $users = $this->Groups->Users->find('list', ['limit' => 500]);
@@ -116,17 +116,17 @@ class GroupsController extends AppController
      * Delete method
      *
      * @param string|null $id Group id.
-     * @return \Cake\Network\Response|null Redirects to index.
-     * @throws \Cake\Network\Exception\NotFoundException When record not found.
+     * @return \Cake\Http\Response|void|null Redirects to index.
+     * @throws \Cake\Http\Exception\NotFoundException When record not found.
      */
-    public function delete($id = null)
+    public function delete(string $id = null)
     {
         $this->request->allowMethod(['post', 'delete']);
         $group = $this->Groups->get($id);
         if ($this->Groups->delete($group)) {
-            $this->Flash->success(__('The group has been deleted.'));
+            $this->Flash->success((string)__('The group has been deleted.'));
         } else {
-            $this->Flash->error(__('The group could not be deleted. Please, try again.'));
+            $this->Flash->error((string)__('The group could not be deleted. Please, try again.'));
         }
 
         return $this->redirect(['action' => 'index']);

--- a/src/Model/Table/GroupsTable.php
+++ b/src/Model/Table/GroupsTable.php
@@ -113,10 +113,10 @@ class GroupsTable extends Table
      * Method that retrieves specified user's groups as list.
      *
      * @param string $userId user id
-     * @param array $options Query options
-     * @return array
+     * @param mixed[] $options Query options
+     * @return mixed[]
      */
-    public function getUserGroups($userId, array $options = [])
+    public function getUserGroups(string $userId, array $options = []): array
     {
         $query = $this->find('list', [
             'keyField' => 'id',
@@ -134,10 +134,10 @@ class GroupsTable extends Table
      * Method that retrieves specified user's groups.
      *
      * @param string $userId user id
-     * @param array $options Query options
-     * @return array
+     * @param mixed[] $options Query options
+     * @return mixed[]
      */
-    public function getUserGroupsAll($userId, array $options = [])
+    public function getUserGroupsAll(string $userId, array $options = []): array
     {
         $query = $this->find('all');
 
@@ -152,9 +152,9 @@ class GroupsTable extends Table
     /**
      * Fetch remote groups.
      *
-     * @return array
+     * @return mixed[]
      */
-    public function getRemoteGroups()
+    public function getRemoteGroups(): array
     {
         $result = [];
 
@@ -172,9 +172,9 @@ class GroupsTable extends Table
     /**
      * Fetch LDAP groups.
      *
-     * @return array
+     * @return mixed[]
      */
-    protected function _getLdapGroups()
+    protected function _getLdapGroups(): array
     {
         $result = [];
 
@@ -184,7 +184,7 @@ class GroupsTable extends Table
         }
 
         $connection = $this->_ldapConnect($config);
-        if (!$connection) {
+        if (!is_resource($connection)) {
             return $result;
         }
 
@@ -206,7 +206,7 @@ class GroupsTable extends Table
     /**
      * Connect to LDAP server.
      *
-     * @param array $config LDAP configuration
+     * @param mixed[] $config LDAP configuration
      * @return resource LDAP connection
      */
     protected function _ldapConnect(array $config)
@@ -233,10 +233,10 @@ class GroupsTable extends Table
     /**
      * Normalizes LDAP result.
      *
-     * @param array $data LDAP result
-     * @return array
+     * @param mixed[] $data LDAP result
+     * @return mixed[]
      */
-    protected function _normalizeResult($data)
+    protected function _normalizeResult(array $data): array
     {
         $result = [];
         for ($i = 0; $i < $data['count']; $i++) {

--- a/src/Model/Table/GroupsTable.php
+++ b/src/Model/Table/GroupsTable.php
@@ -54,9 +54,9 @@ class GroupsTable extends Table
     {
         parent::initialize($config);
 
-        $this->table('qobo_groups');
-        $this->displayField('name');
-        $this->primaryKey('id');
+        $this->setTable('qobo_groups');
+        $this->setDisplayField('name');
+        $this->setPrimaryKey('id');
 
         $this->addBehavior('Timestamp');
         $this->addBehavior('Muffin/Trash.Trash');

--- a/src/Shell/GroupShell.php
+++ b/src/Shell/GroupShell.php
@@ -14,6 +14,14 @@ namespace Groups\Shell;
 use Cake\Console\ConsoleOptionParser;
 use Cake\Console\Shell;
 
+/**
+ * Group shell
+ *
+ * @property \Groups\Shell\Task\AssignTask $Assign
+ * @property \Groups\Shell\Task\ImportTask $Import
+ * @property \Groups\Shell\Task\UserGroupCleanupTask $UserGroupCleanup
+ * @property \Groups\Shell\Task\SyncLdapGroupsTask $SyncLdapGroups
+ */
 class GroupShell extends Shell
 {
     /**
@@ -39,6 +47,9 @@ class GroupShell extends Shell
      */
     public function getOptionParser()
     {
+        /**
+         * @var \Cake\Console\ConsoleOptionParser $parser
+         */
         $parser = parent::getOptionParser();
 
         $parser

--- a/src/Shell/Task/AssignTask.php
+++ b/src/Shell/Task/AssignTask.php
@@ -40,8 +40,11 @@ class AssignTask extends Shell
             return true;
         }
 
-        // Get default group entity
+        /**
+         * @var \Groups\Model\Table\GroupsTable $table
+         */
         $table = TableRegistry::get('Groups.Groups');
+        // Get default group entity
         $group = $table->findByName($groupName)->first();
         if (empty($group)) {
             $this->warn("Default group [$groupName] does not exist.  Nothing to do.");

--- a/src/Shell/Task/ImportTask.php
+++ b/src/Shell/Task/ImportTask.php
@@ -13,7 +13,7 @@ namespace Groups\Shell\Task;
 
 use Cake\Console\Shell;
 use Cake\Core\Configure;
-use Cake\ORM\Entity;
+use Cake\Datasource\EntityInterface;
 use Cake\ORM\TableRegistry;
 
 /**
@@ -70,18 +70,23 @@ class ImportTask extends Shell
     /**
      * Get import errors from entity object.
      *
-     * @param  \Cake\ORM\Entity $entity Entity instance
-     * @return array
+     * @param  \Cake\Datasource\EntityInterface $entity Entity instance
+     * @return string[]
      */
-    protected function getImportErrors(Entity $entity)
+    protected function getImportErrors(EntityInterface $entity): array
     {
         $result = [];
 
-        if (empty($entity->errors())) {
+        /**
+         * @var array $errors
+         */
+        $errors = $entity->errors();
+
+        if (empty($errors)) {
             return $result;
         }
 
-        foreach ($entity->errors() as $field => $error) {
+        foreach ($errors as $field => $error) {
             $msg = "[$field] ";
             $msg .= is_array($error) ? implode(', ', $error) : $error;
             $result[] = $msg;

--- a/src/Template/Groups/add.ctp
+++ b/src/Template/Groups/add.ctp
@@ -45,10 +45,10 @@ echo $this->Html->script(
                 <div class="box-body">
                     <div class="row">
                         <div class="col-md-6">
-                            <?= $this->Form->input('name'); ?>
+                            <?= $this->Form->control('name'); ?>
                         </div>
                         <div class="col-md-6">
-                            <?= $this->Form->input('description'); ?>
+                            <?= $this->Form->control('description'); ?>
                         </div>
                     </div>
                     <div class="row">

--- a/src/Template/Groups/edit.ctp
+++ b/src/Template/Groups/edit.ctp
@@ -45,10 +45,10 @@ echo $this->Html->script(
                 <div class="box-body">
                     <div class="row">
                         <div class="col-md-6">
-                            <?= $this->Form->input('name'); ?>
+                            <?= $this->Form->control('name'); ?>
                         </div>
                         <div class="col-md-6">
-                            <?= $this->Form->input('description'); ?>
+                            <?= $this->Form->control('description'); ?>
                         </div>
                     </div>
                     <div class="row">

--- a/tests/App/Application.php
+++ b/tests/App/Application.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link      https://cakephp.org CakePHP(tm) Project
+ * @since     3.3.0
+ * @license   https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Groups\Test\App;
+
+use Cake\Core\Configure;
+use Cake\Error\Middleware\ErrorHandlerMiddleware;
+use Cake\Http\BaseApplication;
+use Cake\Routing\Middleware\AssetMiddleware;
+use Cake\Routing\Middleware\RoutingMiddleware;
+
+/**
+ * Application setup class.
+ *
+ * This defines the bootstrapping logic and middleware layers you
+ * want to use in your application.
+ */
+class Application extends BaseApplication
+{
+    /**
+     * Setup the middleware queue your application will use.
+     *
+     * @param \Cake\Http\MiddlewareQueue $middlewareQueue The middleware queue to setup.
+     * @return \Cake\Http\MiddlewareQueue The updated middleware queue.
+     */
+    public function middleware($middlewareQueue)
+    {
+        $middlewareQueue
+            // Catch any exceptions in the lower layers,
+            // and make an error page/response
+            ->add(ErrorHandlerMiddleware::class)
+
+            // Handle plugin/theme assets like CakePHP normally does.
+            ->add(AssetMiddleware::class)
+
+            // Add routing middleware.
+            ->add(new RoutingMiddleware($this));
+
+        return $middlewareQueue;
+    }
+}

--- a/tests/App/Controller/AppController.php
+++ b/tests/App/Controller/AppController.php
@@ -5,5 +5,16 @@ use \Cake\Controller\Controller;
 
 class AppController extends Controller
 {
-    public $components = ['Auth', 'Flash', 'RequestHandler'];
+    public function initialize()
+    {
+        parent::initialize();
+        $this->loadComponent('Auth', [
+            'authenticate' => ['Form']
+        ]);
+
+        $this->loadComponent('Flash');
+        $this->loadComponent('RequestHandler', [
+            'enableBeforeRedirect' => false,
+        ]);
+    }
 }

--- a/tests/App/Controller/UsersController.php
+++ b/tests/App/Controller/UsersController.php
@@ -1,14 +1,16 @@
 <?php
 namespace Groups\Test\App\Controller;
 
-use \Cake\Controller\Controller;
+use Cake\Controller\Controller;
 
 class UsersController extends Controller
 {
     /**
      * Simple users login action
+     *
+     * @return void
      */
-    public function login()
+    public function login(): void
     {
     }
 }

--- a/tests/TestCase/Controller/Component/GroupComponentTest.php
+++ b/tests/TestCase/Controller/Component/GroupComponentTest.php
@@ -9,6 +9,8 @@ use Groups\Controller\Component\GroupComponent;
 
 /**
  * Groups\Controller\Component\GroupComponent Test Case
+ *
+ * @property \Groups\Controller\Component\GroupComponent $GroupComponent
  */
 class GroupComponentTest extends TestCase
 {

--- a/tests/TestCase/Controller/Component/GroupComponentTest.php
+++ b/tests/TestCase/Controller/Component/GroupComponentTest.php
@@ -40,7 +40,7 @@ class GroupComponentTest extends TestCase
         parent::tearDown();
     }
 
-    public function testGetUserGroups()
+    public function testGetUserGroups(): void
     {
         $result = $this->GroupComponent->getUserGroups('00000000-0000-0000-0000-000000000001');
 
@@ -48,7 +48,7 @@ class GroupComponentTest extends TestCase
         $this->assertEquals(1, count($result));
     }
 
-    public function testGetUserGroupsWithoutUserId()
+    public function testGetUserGroupsWithoutUserId(): void
     {
         $this->GroupComponent->Auth->setUser(['id' => '00000000-0000-0000-0000-000000000001']);
 

--- a/tests/TestCase/Controller/GroupsControllerTest.php
+++ b/tests/TestCase/Controller/GroupsControllerTest.php
@@ -11,6 +11,8 @@ use Groups\Model\Entity\Group;
 
 /**
  * Groups\Controller\GroupsController Test Case
+ *
+ * @property \Groups\Model\Table\GroupsTable $Groups
  */
 class GroupsControllerTest extends IntegrationTestCase
 {
@@ -24,7 +26,11 @@ class GroupsControllerTest extends IntegrationTestCase
     {
         parent::setUp();
 
-        $this->Groups = TableRegistry::get('Groups.Groups');
+        /**
+         * @var \Groups\Model\Table\GroupsTable $table
+         */
+        $table = TableRegistry::get('Groups.Groups');
+        $this->Groups = $table;
 
         // Run all tests as authenticated user
         $this->session(['Auth.User.id' => '00000000-0000-0000-0000-000000000001']);
@@ -42,7 +48,7 @@ class GroupsControllerTest extends IntegrationTestCase
         parent::tearDown();
     }
 
-    public function testIndex()
+    public function testIndex(): void
     {
         $this->get('/groups/groups');
 
@@ -53,7 +59,7 @@ class GroupsControllerTest extends IntegrationTestCase
         $this->assertEquals(3, $groups->count());
     }
 
-    public function testView()
+    public function testView(): void
     {
         $id = '00000000-0000-0000-0000-000000000001';
         $this->get('/groups/groups/view/' . $id);
@@ -64,7 +70,7 @@ class GroupsControllerTest extends IntegrationTestCase
         $this->assertInstanceOf(Group::class, $group);
     }
 
-    public function testAdd()
+    public function testAdd(): void
     {
         $expected = 1 + $this->Groups->find('all')->count();
 
@@ -82,7 +88,7 @@ class GroupsControllerTest extends IntegrationTestCase
         $this->assertEquals($expected, $this->Groups->find('all')->count());
     }
 
-    public function testAddExistingName()
+    public function testAddExistingName(): void
     {
         $data = ['name' => 'Lorem ipsum dolor sit amet'];
 
@@ -91,7 +97,7 @@ class GroupsControllerTest extends IntegrationTestCase
         $this->assertSession('The group could not be saved. Please, try again.', 'Flash.flash.0.message');
     }
 
-    public function testAddGet()
+    public function testAddGet(): void
     {
         $this->get('/groups/groups/add');
 
@@ -108,7 +114,7 @@ class GroupsControllerTest extends IntegrationTestCase
         $this->assertInternalType('array', $remoteGroups);
     }
 
-    public function testEdit()
+    public function testEdit(): void
     {
         $id = '00000000-0000-0000-0000-000000000001';
 
@@ -130,7 +136,7 @@ class GroupsControllerTest extends IntegrationTestCase
         $this->assertNotEquals($entity->get('name'), $result->get('name'));
     }
 
-    public function testEditGet()
+    public function testEditGet(): void
     {
         $id = '00000000-0000-0000-0000-000000000001';
 
@@ -149,7 +155,7 @@ class GroupsControllerTest extends IntegrationTestCase
         $this->assertInternalType('array', $remoteGroups);
     }
 
-    public function testDelete()
+    public function testDelete(): void
     {
         $expected = $this->Groups->find('all')->count() - 1;
 

--- a/tests/TestCase/Model/Table/GroupsTableTest.php
+++ b/tests/TestCase/Model/Table/GroupsTableTest.php
@@ -57,7 +57,7 @@ class GroupsTableTest extends TestCase
     {
         $this->assertTrue($this->Groups->hasBehavior('Timestamp'));
         $this->assertTrue($this->Groups->hasBehavior('Trash'));
-        $this->assertInstanceOf(BelongsToMany::class, $this->Groups->association('Users'));
+        $this->assertInstanceOf(BelongsToMany::class, $this->Groups->getAssociation('Users'));
         $this->assertInstanceOf(GroupsTable::class, $this->Groups);
     }
 
@@ -76,7 +76,7 @@ class GroupsTableTest extends TestCase
         $data = ['name' => 'Foobar'];
 
         $entity = $this->Groups->newEntity($data);
-        $this->assertEmpty($entity->errors());
+        $this->assertEmpty($entity->getErrors());
     }
 
     public function testSave()
@@ -142,6 +142,6 @@ class GroupsTableTest extends TestCase
         $entity = $this->Groups->patchEntity($entity, ['name' => 'Lorem ipsum dolor sit amet']);
 
         $this->assertFalse($this->Groups->save($entity));
-        $this->assertNotEmpty($entity->errors());
+        $this->assertNotEmpty($entity->getErrors());
     }
 }

--- a/tests/TestCase/Model/Table/GroupsTableTest.php
+++ b/tests/TestCase/Model/Table/GroupsTableTest.php
@@ -9,6 +9,8 @@ use Groups\Model\Table\GroupsTable;
 
 /**
  * Groups\Model\Table\GroupsTable Test Case
+ *
+ * @property \Groups\Model\Table\GroupsTable $Groups
  */
 class GroupsTableTest extends TestCase
 {
@@ -33,7 +35,11 @@ class GroupsTableTest extends TestCase
     {
         parent::setUp();
         $config = TableRegistry::exists('Groups') ? [] : ['className' => 'Groups\Model\Table\GroupsTable'];
-        $this->Groups = TableRegistry::get('Groups', $config);
+        /**
+         * @var \Groups\Model\Table\GroupsTable $table
+         */
+        $table = TableRegistry::get('Groups', $config);
+        $this->Groups = $table;
     }
 
     /**
@@ -53,7 +59,7 @@ class GroupsTableTest extends TestCase
      *
      * @return void
      */
-    public function testInitialize()
+    public function testInitialize(): void
     {
         $this->assertTrue($this->Groups->hasBehavior('Timestamp'));
         $this->assertTrue($this->Groups->hasBehavior('Trash'));
@@ -66,7 +72,7 @@ class GroupsTableTest extends TestCase
      *
      * @return void
      */
-    public function testValidationDefault()
+    public function testValidationDefault(): void
     {
         $validator = new \Cake\Validation\Validator();
         $result = $this->Groups->validationDefault($validator);
@@ -79,17 +85,19 @@ class GroupsTableTest extends TestCase
         $this->assertEmpty($entity->getErrors());
     }
 
-    public function testSave()
+    public function testSave(): void
     {
         $data = ['name' => 'Foobar', 'description' => 'Foobar group', 'deny_edit' => false, 'deny_delete' => false];
 
         $entity = $this->Groups->newEntity($data);
         $result = $this->Groups->save($entity);
-
-        $this->assertNotEmpty($result->get('id'));
+        $this->assertTrue(is_object($result), "Result is not an entity");
+        if (is_object($result)) {
+            $this->assertNotEmpty($result->get('id'));
+        }
     }
 
-    public function testGetUserGroups()
+    public function testGetUserGroups(): void
     {
         $result = $this->Groups->getUserGroups('00000000-0000-0000-0000-000000000001');
 
@@ -97,7 +105,7 @@ class GroupsTableTest extends TestCase
         $this->assertEquals(1, count($result));
     }
 
-    public function testGetUserGroupsAll()
+    public function testGetUserGroupsAll(): void
     {
         $userId = '00000000-0000-0000-0000-000000000001';
 
@@ -108,7 +116,7 @@ class GroupsTableTest extends TestCase
         $this->assertInstanceOf('Groups\Model\Entity\Group', $result[0]);
     }
 
-    public function testGetRemoteGroupsDummyConfig()
+    public function testGetRemoteGroupsDummyConfig(): void
     {
         Configure::write('Groups.remoteGroups.enabled', true);
         Configure::write('Groups.remoteGroups.LDAP', [
@@ -128,7 +136,7 @@ class GroupsTableTest extends TestCase
         $this->assertEmpty($result);
     }
 
-    public function testGetRemoteGroupsNotEnabled()
+    public function testGetRemoteGroupsNotEnabled(): void
     {
         $result = $this->Groups->getRemoteGroups();
 
@@ -136,12 +144,15 @@ class GroupsTableTest extends TestCase
         $this->assertEmpty($result);
     }
 
-    public function testSaveGroupWithExistingName()
+    public function testSaveGroupWithExistingName(): void
     {
         $entity = $this->Groups->newEntity();
         $entity = $this->Groups->patchEntity($entity, ['name' => 'Lorem ipsum dolor sit amet']);
-
-        $this->assertFalse($this->Groups->save($entity));
+        $result = $this->Groups->save($entity);
+        $this->assertTrue(is_bool($result), "Result is not a boolean");
+        if (is_bool($result)) {
+            $this->assertFalse($result);
+        }
         $this->assertNotEmpty($entity->getErrors());
     }
 }

--- a/tests/TestCase/Shell/Task/AssignTaskTest.php
+++ b/tests/TestCase/Shell/Task/AssignTaskTest.php
@@ -6,6 +6,10 @@ use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 use Groups\Shell\Task\AssignTask;
 
+/**
+ * @property \Groups\Model\Table\GroupsTable $Groups
+ * @property \CakeDC\Users\Model\Table\UsersTable $Users
+ */
 class AssignTaskTest extends TestCase
 {
     public $fixtures = [
@@ -18,8 +22,17 @@ class AssignTaskTest extends TestCase
     {
         parent::setUp();
 
-        $this->Groups = TableRegistry::get('Groups.Groups');
-        $this->Users = TableRegistry::get('CakeDC/Users.Users');
+        /**
+         * @var \Groups\Model\Table\GroupsTable $table
+         */
+        $table = TableRegistry::get('Groups.Groups');
+        $this->Groups = $table;
+
+        /**
+         * @var \CakeDC\Users\Model\Table\UsersTable $table
+         */
+        $table = TableRegistry::get('CakeDC/Users.Users');
+        $this->Users = $table;
 
         $this->io = $this->getMockBuilder('Cake\Console\ConsoleIo')
             ->disableOriginalConstructor()
@@ -43,7 +56,7 @@ class AssignTaskTest extends TestCase
         parent::tearDown();
     }
 
-    public function testMain()
+    public function testMain(): void
     {
         $data = ['name' => Configure::read('Groups.defaultGroup')];
 
@@ -58,7 +71,14 @@ class AssignTaskTest extends TestCase
 
         $this->Task->main();
 
-        $entity = $this->Groups->find()->where($data)->contain('Users')->first();
-        $this->assertEquals($expected, count($entity->get('users')));
+        $groups = $this->Groups->find()->where($data)->contain('Users');
+        $this->assertTrue(is_object($groups), "Groups is not an object");
+        if (is_object($groups)) {
+            $entity = $groups->first();
+            $this->assertTrue(is_object($entity), "First user is not an object");
+            if (is_object($entity)) {
+                $this->assertEquals($expected, count($entity->get('users')));
+            }
+        }
     }
 }

--- a/tests/TestCase/Shell/Task/ImportTaskTest.php
+++ b/tests/TestCase/Shell/Task/ImportTaskTest.php
@@ -5,6 +5,9 @@ use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 use Groups\Shell\Task\ImportTask;
 
+/**
+ * @property \Groups\Model\Table\GroupsTable $Groups
+ */
 class ImportTaskTest extends TestCase
 {
     public $fixtures = [
@@ -15,7 +18,11 @@ class ImportTaskTest extends TestCase
     {
         parent::setUp();
 
-        $this->Groups = TableRegistry::get('Groups.Groups');
+        /**
+         * @var \Groups\Model\Table\GroupsTable $table
+         */
+        $table = TableRegistry::get('Groups.Groups');
+        $this->Groups = $table;
 
         $this->io = $this->getMockBuilder('Cake\Console\ConsoleIo')
             ->disableOriginalConstructor()
@@ -36,13 +43,21 @@ class ImportTaskTest extends TestCase
         parent::tearDown();
     }
 
-    public function testMain()
+    public function testMain(): void
     {
         $group = $this->Groups->find()->where(['name' => 'Admins'])->first();
-        $this->Groups->delete($group);
+        $this->assertFalse(empty($group), "No Admins group found");
+        $this->assertTrue(is_object($group), "Admins group is not an object");
+        if (!empty($group) && is_object($group)) {
+            $this->Groups->delete($group);
+        }
 
         $group = $this->Groups->find()->where(['name' => 'Everyone'])->first();
-        $this->Groups->delete($group);
+        $this->assertFalse(empty($group), "No Everyone group found");
+        $this->assertTrue(is_object($group), "Everyone group is not an object");
+        if (!empty($group) && is_object($group)) {
+            $this->Groups->delete($group);
+        }
 
         $this->Task->main();
 

--- a/tests/TestCase/Shell/Task/UserGroupCleanupTaskTest.php
+++ b/tests/TestCase/Shell/Task/UserGroupCleanupTaskTest.php
@@ -6,6 +6,10 @@ use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 use Groups\Shell\Task\UserGroupCleanupTask;
 
+/**
+ * @property \Groups\Model\Table\GroupsTable $Groups
+ * @property \CakeDC\Users\Model\Table\UsersTable $Users
+ */
 class UserGroupCleanupTaskTest extends TestCase
 {
     public $fixtures = [
@@ -18,8 +22,17 @@ class UserGroupCleanupTaskTest extends TestCase
     {
         parent::setUp();
 
-        $this->Groups = TableRegistry::get('Groups.Groups');
-        $this->Users = TableRegistry::get('CakeDC/Users.Users');
+        /**
+         * @var \Groups\Model\Table\GroupsTable
+         */
+        $table = TableRegistry::get('Groups.Groups');
+        $this->Groups = $table;
+
+        /**
+         * @var \CakeDC\Users\Model\Table\UsersTable
+         */
+        $table = TableRegistry::get('CakeDC/Users.Users');
+        $this->Users = $table;
 
         $this->io = $this->getMockBuilder('Cake\Console\ConsoleIo')
             ->disableOriginalConstructor()
@@ -43,7 +56,7 @@ class UserGroupCleanupTaskTest extends TestCase
         parent::tearDown();
     }
 
-    public function testMain()
+    public function testMain(): void
     {
         $group = $this->Groups->get('00000000-0000-0000-0000-000000000001');
         $user = $this->Users->get('00000000-0000-0000-0000-000000000001');

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,37 +1,34 @@
 <?php
-// @codingStandardsIgnoreFile
-
 use Cake\Core\Configure;
 use Cake\Filesystem\Folder;
 
 $pluginName = 'Groups';
 if (empty($pluginName)) {
-    throw new \Exception("Plugin name is not configured");
+    throw new \RuntimeException("Plugin name is not configured");
 }
 
-$findRoot = function () {
-    $root = dirname(__DIR__);
-    if (is_dir($root . '/vendor/cakephp/cakephp')) {
-        return $root;
-    }
-
-    $root = dirname(dirname(__DIR__));
-    if (is_dir($root . '/vendor/cakephp/cakephp')) {
-        return $root;
-    }
-
-    $root = dirname(dirname(dirname(__DIR__)));
-    if (is_dir($root . '/vendor/cakephp/cakephp')) {
-        return $root;
-    }
-
-    throw new \Exception("Failed to find CakePHP");
+/*
+ * Test suite bootstrap
+ *
+ * This function is used to find the location of CakePHP whether CakePHP
+ * has been installed as a dependency of the plugin, or the plugin is itself
+ * installed as a dependency of an application.
+ */
+$findRoot = function ($root) {
+    do {
+        $lastRoot = $root;
+        $root = dirname($root);
+        if (is_dir($root . '/vendor/cakephp/cakephp')) {
+            return $root;
+        }
+    } while ($root !== $lastRoot);
+    throw new \RuntimeException("Failed to find CakePHP");
 };
 
 if (!defined('DS')) {
     define('DS', DIRECTORY_SEPARATOR);
 }
-define('ROOT', $findRoot());
+define('ROOT', $findRoot(__FILE__));
 define('APP_DIR', 'App');
 define('WEBROOT_DIR', 'webroot');
 define('APP', ROOT . '/tests/App/');
@@ -83,7 +80,7 @@ $cache = [
     ]
 ];
 
-Cake\Cache\Cache::config($cache);
+Cake\Cache\Cache::setConfig($cache);
 Cake\Core\Configure::write('Session', [
     'defaults' => 'php'
 ]);
@@ -93,13 +90,13 @@ if (!getenv('db_dsn')) {
     putenv('db_dsn=sqlite:///:memory:');
 }
 
-Cake\Datasource\ConnectionManager::config('default', [
+Cake\Datasource\ConnectionManager::setConfig('default', [
     'url' => getenv('db_dsn'),
     'quoteIdentifiers' => true,
     'timezone' => 'UTC'
 ]);
 
-Cake\Datasource\ConnectionManager::config('test', [
+Cake\Datasource\ConnectionManager::setConfig('test', [
     'url' => getenv('db_dsn'),
     'quoteIdentifiers' => true,
     'timezone' => 'UTC'
@@ -108,10 +105,7 @@ Cake\Datasource\ConnectionManager::config('test', [
 // Alias AppController to the test App
 class_alias($pluginName . '\Test\App\Controller\AppController', 'App\Controller\AppController');
 // If plugin has routes.php/bootstrap.php then load them, otherwise don't.
-$loadPluginRoutes = file_exists(dirname(__FILE__) . DS . 'config' . DS . 'routes.php');
-$loadPluginBootstrap = file_exists(dirname(__FILE__) . DS . 'config' . DS . 'bootstrap.php');
+$loadPluginRoutes = file_exists(ROOT . DS . 'config' . DS . 'routes.php');
+$loadPluginBootstrap = file_exists(ROOT . DS . 'config' . DS . 'bootstrap.php');
 Cake\Core\Plugin::load($pluginName, ['path' => ROOT . DS, 'autoload' => true, 'routes' => $loadPluginRoutes, 'bootstrap' => $loadPluginBootstrap]);
 Cake\Core\Plugin::load('CakeDC/Users', ['routes' => true, 'bootstrap' => true]);
-
-Cake\Routing\DispatcherFactory::add('Routing');
-Cake\Routing\DispatcherFactory::add('ControllerFactory');

--- a/tests/config/routes.php
+++ b/tests/config/routes.php
@@ -1,10 +1,8 @@
 <?php
 namespace Groups\Test\App\Config;
 
+use Cake\Core\Configure;
 use Cake\Core\Plugin;
 use Cake\Routing\Router;
-
-// Load all plugin routes. See the Plugin documentation on how to customize the loading of plugin routes.
-Plugin::routes();
 
 Router::connect('/users/login', ['controller' => 'Users', 'action' => 'login']);


### PR DESCRIPTION
* Updated to [cakephp-plugin-template v5.2.1](https://github.com/QoboLtd/cakephp-plugin-template/releases/tag/v5.2.1).
* Updated `composer.json`.
* Fixed most of deprecated errors for CakePHP 3.6
* Fixed most of PHPStan issues.
