### PR TITLE
Group import improvement (task #11200)

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -9,11 +9,6 @@ parameters:
     earlyTerminatingMethodCalls:
         Cake\Console\Shell:
             - abort
-    ignoreErrors:
-        # This ignore rule an be removed once the patch is released:
-        # PR link: https://github.com/phpstan/phpstan/pull/1588
-        # Issue link: https://github.com/phpstan/phpstan/issues/1585
-        - '#Function ldap_control_paged_result_response invoked with 3 parameters, 4 required.#'
 includes:
     - vendor/phpstan/phpstan-webmozart-assert/extension.neon
     - vendor/thecodingmachine/phpstan-strict-rules/phpstan-strict-rules.neon

--- a/src/Model/Table/GroupsTable.php
+++ b/src/Model/Table/GroupsTable.php
@@ -198,7 +198,7 @@ class GroupsTable extends Table
         $result = ldap_get_entries($connection, $search);
 
         if (empty($result)) {
-            return $result;
+            return [];
         }
 
         return $this->_normalizeResult($result);

--- a/src/Shell/Task/ImportTask.php
+++ b/src/Shell/Task/ImportTask.php
@@ -15,6 +15,7 @@ use Cake\Console\Shell;
 use Cake\Core\Configure;
 use Cake\Datasource\EntityInterface;
 use Cake\ORM\TableRegistry;
+use Webmozart\Assert\Assert;
 
 /**
  * Import Task
@@ -50,6 +51,7 @@ class ImportTask extends Shell
             }
 
             $entity = $table->find()->where(['name' => $group['name']])->first();
+            Assert::nullOrIsInstanceOf($entity, EntityInterface::class);
 
             if (null !== $entity && $entity->get('deny_edit')) {
                 $this->warn(sprintf('Group "%s" already exists and is not allowed to be modified.', $group['name']));

--- a/src/Shell/Task/ImportTask.php
+++ b/src/Shell/Task/ImportTask.php
@@ -35,7 +35,7 @@ class ImportTask extends Shell
 
         $systemGroups = Configure::read('Groups.systemGroups');
         if (empty($systemGroups)) {
-            $this->warn("System groups are not configured.  Nothing to do.");
+            $this->warn("System groups are not configured. Nothing to do.");
 
             return true;
         }
@@ -49,16 +49,22 @@ class ImportTask extends Shell
                 continue;
             }
 
-            if ($table->exists(['name' => $group['name']])) {
-                $this->warn("Group [" . $group['name'] . "] already exists. Skipping.");
+            $entity = $table->find()->where(['name' => $group['name']])->first();
+
+            if (null !== $entity && $entity->get('deny_edit')) {
+                $this->warn(sprintf('Group "%s" already exists and is not allowed to be modified.', $group['name']));
                 continue;
             }
 
-            $this->info("Group [" . $group['name'] . "] does not exist. Creating.");
-            $entity = $table->newEntity();
+            null === $entity ?
+                $this->info(sprintf('Creating group "%s".', $group['name'])) :
+                $this->info(sprintf('Updating group "%s".', $group['name']));
+
+            $entity = null === $entity ? $table->newEntity() : $entity;
+            $original = $entity->ToArray();
             $entity = $table->patchEntity($entity, $group);
-            $result = $table->save($entity);
-            if (!$result) {
+
+            if (! $table->save($entity)) {
                 $this->err("Errors: \n" . implode("\n", $this->getImportErrors($entity)));
                 $this->abort("Failed to create group [" . $group['name'] . "]");
             }
@@ -76,17 +82,7 @@ class ImportTask extends Shell
     protected function getImportErrors(EntityInterface $entity): array
     {
         $result = [];
-
-        /**
-         * @var array $errors
-         */
-        $errors = $entity->errors();
-
-        if (empty($errors)) {
-            return $result;
-        }
-
-        foreach ($errors as $field => $error) {
+        foreach ($entity->getErrors() as $field => $error) {
             $msg = "[$field] ";
             $msg .= is_array($error) ? implode(', ', $error) : $error;
             $result[] = $msg;

--- a/src/Shell/Task/ImportTask.php
+++ b/src/Shell/Task/ImportTask.php
@@ -63,7 +63,6 @@ class ImportTask extends Shell
                 $this->info(sprintf('Updating group "%s".', $group['name']));
 
             $entity = null === $entity ? $table->newEntity() : $entity;
-            $original = $entity->ToArray();
             $entity = $table->patchEntity($entity, $group);
 
             if (! $table->save($entity)) {

--- a/tests/TestCase/Shell/Task/ImportTaskTest.php
+++ b/tests/TestCase/Shell/Task/ImportTaskTest.php
@@ -52,7 +52,6 @@ class ImportTaskTest extends TestCase
     {
         $this->Groups->deleteAll([]);
 
-
         $this->Task->main();
 
         $query = $this->Groups->find()->where(['name' => $data['name']]);

--- a/tests/TestCase/Shell/Task/ImportTaskTest.php
+++ b/tests/TestCase/Shell/Task/ImportTaskTest.php
@@ -4,6 +4,7 @@ namespace Groups\Test\TestCase\Shell\Task;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 use Groups\Shell\Task\ImportTask;
+use Webmozart\Assert\Assert;
 
 /**
  * @property \Groups\Model\Table\GroupsTable $Groups
@@ -57,7 +58,10 @@ class ImportTaskTest extends TestCase
         $query = $this->Groups->find()->where(['name' => $data['name']]);
         $this->assertSame(1, $query->count());
 
-        $group = $query->firstOrFail()->toArray();
+        $entity = $query->firstOrFail();
+        Assert::nullOrIsInstanceOf($entity, \Cake\Datasource\EntityInterface::class);
+        $group = $entity->toArray();
+
         $this->assertSame([], array_diff_assoc($data, $group));
         $initialModifiedDate = $group['modified'];
 
@@ -68,10 +72,10 @@ class ImportTaskTest extends TestCase
 
         $this->Task->main();
 
-        $updated = $this->Groups->find()
-            ->where(['name' => $data['name']])
-            ->firstOrFail()
-            ->toArray();
+        $entity = $this->Groups->find()->where(['name' => $data['name']])->firstOrFail();
+        Assert::nullOrIsInstanceOf($entity, \Cake\Datasource\EntityInterface::class);
+        $updated = $entity->toArray();
+
 
         $data['deny_edit'] ?
             $this->assertTrue($updated['modified']->getTimestamp() === $initialModifiedDate->getTimestamp()) :

--- a/tests/TestCase/Shell/Task/ImportTaskTest.php
+++ b/tests/TestCase/Shell/Task/ImportTaskTest.php
@@ -76,7 +76,6 @@ class ImportTaskTest extends TestCase
         Assert::nullOrIsInstanceOf($entity, \Cake\Datasource\EntityInterface::class);
         $updated = $entity->toArray();
 
-
         $data['deny_edit'] ?
             $this->assertTrue($updated['modified']->getTimestamp() === $initialModifiedDate->getTimestamp()) :
             $this->assertTrue($updated['modified']->getTimestamp() > $initialModifiedDate->getTimestamp());


### PR DESCRIPTION
This PR brings an improvement on groups import shell to allow updating existing system groups. System groups which are already flagged as _deny edit_, will still be skipped.