### PR TITLE
Read users table from config (task #15561)

### DIFF
--- a/src/Model/Table/GroupsTable.php
+++ b/src/Model/Table/GroupsTable.php
@@ -65,7 +65,7 @@ class GroupsTable extends Table
             'foreignKey' => 'group_id',
             'targetForeignKey' => 'user_id',
             'joinTable' => 'groups_users',
-            'className' => 'CakeDC/Users.Users',
+            'className' => Configure::read('Users.table', 'CakeDC/Users.Users'),
         ]);
     }
 


### PR DESCRIPTION
When creating an association between groups and users tables, use the value from `Users.table` config parameter, with a fallback to CakeDC users table.