### PR TITLE
Support for CakePHP v3.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,14 +21,8 @@
         "sort-packages": true,
         "optimize-autoloader": true
     },
-    "repositories": [
-        {
-            "type": "git",
-            "url": "https://github.com/QoboLtd/cakephp-file-storage.git"
-        }
-    ],
     "require": {
-        "cakephp/cakephp": "^3.5 <3.7",
+        "cakephp/cakephp": "^3.6",
         "cakedc/users": "^8.0",
         "muffin/trash": "^2.1"
     },
@@ -62,6 +56,5 @@
         "test": "Runs phpcs and phpunit without coverage",
         "test-coverage": "Runs phpcs and phpunit with coverage enabled"
     },
-    "prefer-stable": true,
-    "minimum-stability": "dev"
+    "prefer-stable": true
 }

--- a/config/Migrations/20180516105842_RenameGroupsTable.php
+++ b/config/Migrations/20180516105842_RenameGroupsTable.php
@@ -13,6 +13,7 @@ class RenameGroupsTable extends AbstractMigration
     public function change()
     {
         $this->table('groups')
-            ->rename('qobo_groups');
+            ->rename('qobo_groups')
+            ->update();
     }
 }

--- a/src/Controller/Component/GroupComponent.php
+++ b/src/Controller/Component/GroupComponent.php
@@ -45,7 +45,7 @@ class GroupComponent extends Component
             $userId = $this->Auth->user('id');
         }
 
-        $groups = TableRegistry::get('Groups.Groups');
+        $groups = TableRegistry::getTableLocator()->get('Groups.Groups');
 
         $query = $groups->find('list', [
             'keyField' => 'id',

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Groups;
+
+use Cake\Core\BasePlugin;
+
+class Plugin extends BasePlugin
+{
+    protected $name = 'Groups';
+}

--- a/src/Shell/Task/AssignTask.php
+++ b/src/Shell/Task/AssignTask.php
@@ -43,7 +43,7 @@ class AssignTask extends Shell
         /**
          * @var \Groups\Model\Table\GroupsTable $table
          */
-        $table = TableRegistry::get('Groups.Groups');
+        $table = TableRegistry::getTableLocator()->get('Groups.Groups');
         /**
          * Get default group entity.
          *

--- a/src/Shell/Task/ImportTask.php
+++ b/src/Shell/Task/ImportTask.php
@@ -42,7 +42,7 @@ class ImportTask extends Shell
         }
 
         // get groups table
-        $table = TableRegistry::get('Groups.Groups');
+        $table = TableRegistry::getTableLocator()->get('Groups.Groups');
 
         foreach ($systemGroups as $group) {
             if (empty($group['name'])) {

--- a/src/Shell/Task/SyncLdapGroupsTask.php
+++ b/src/Shell/Task/SyncLdapGroupsTask.php
@@ -74,7 +74,7 @@ class SyncLdapGroupsTask extends Shell
             $this->abort('Required parameters are missing: ' . implode(', ', $diff) . '.');
         }
 
-        $groupsTable = TableRegistry::get('Groups.Groups');
+        $groupsTable = TableRegistry::getTableLocator()->get('Groups.Groups');
 
         $groups = $this->getGroups($groupsTable);
         if (empty($groups)) {

--- a/src/Shell/Task/UserGroupCleanupTask.php
+++ b/src/Shell/Task/UserGroupCleanupTask.php
@@ -32,7 +32,7 @@ class UserGroupCleanupTask extends Shell
         $this->hr();
 
         // get groups table
-        $table = TableRegistry::get('Groups.Groups');
+        $table = TableRegistry::getTableLocator()->get('Groups.Groups');
         $query = $table->find('all');
 
         if ($query->isEmpty()) {
@@ -45,7 +45,7 @@ class UserGroupCleanupTask extends Shell
         foreach ($groups as $group) {
             $this->info('Cleaning up ' . $group->name . ' group ..');
 
-            $table = TableRegistry::get('groups_users');
+            $table = TableRegistry::getTableLocator()->get('groups_users');
             $query = $table->find('all')
                 ->where(['group_id' => $group->id])
                 ->select(['user_id'])

--- a/tests/TestCase/Controller/GroupsControllerTest.php
+++ b/tests/TestCase/Controller/GroupsControllerTest.php
@@ -17,8 +17,8 @@ use Groups\Model\Entity\Group;
 class GroupsControllerTest extends IntegrationTestCase
 {
     public $fixtures = [
-        'plugin.groups.groups',
-        'plugin.groups.groups_users',
+        'plugin.Groups.groups',
+        'plugin.Groups.groupsUsers',
         'plugin.CakeDC/Users.users',
     ];
 
@@ -29,7 +29,7 @@ class GroupsControllerTest extends IntegrationTestCase
         /**
          * @var \Groups\Model\Table\GroupsTable $table
          */
-        $table = TableRegistry::get('Groups.Groups');
+        $table = TableRegistry::getTableLocator()->get('Groups.Groups');
         $this->Groups = $table;
 
         // Run all tests as authenticated user

--- a/tests/TestCase/Model/Table/GroupsTableTest.php
+++ b/tests/TestCase/Model/Table/GroupsTableTest.php
@@ -35,11 +35,11 @@ class GroupsTableTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        $config = TableRegistry::exists('Groups') ? [] : ['className' => 'Groups\Model\Table\GroupsTable'];
+        $config = TableRegistry::getTableLocator()->exists('Groups') ? [] : ['className' => 'Groups\Model\Table\GroupsTable'];
         /**
          * @var \Groups\Model\Table\GroupsTable $table
          */
-        $table = TableRegistry::get('Groups', $config);
+        $table = TableRegistry::getTableLocator()->get('Groups', $config);
         $this->Groups = $table;
     }
 

--- a/tests/TestCase/Shell/Task/AssignTaskTest.php
+++ b/tests/TestCase/Shell/Task/AssignTaskTest.php
@@ -30,13 +30,13 @@ class AssignTaskTest extends TestCase
         /**
          * @var \Groups\Model\Table\GroupsTable $table
          */
-        $table = TableRegistry::get('Groups.Groups');
+        $table = TableRegistry::getTableLocator()->get('Groups.Groups');
         $this->Groups = $table;
 
         /**
          * @var \CakeDC\Users\Model\Table\UsersTable $table
          */
-        $table = TableRegistry::get('CakeDC/Users.Users');
+        $table = TableRegistry::getTableLocator()->get('CakeDC/Users.Users');
         $this->Users = $table;
 
         /** @var \Cake\Console\ConsoleIo */

--- a/tests/TestCase/Shell/Task/ImportTaskTest.php
+++ b/tests/TestCase/Shell/Task/ImportTaskTest.php
@@ -28,7 +28,7 @@ class ImportTaskTest extends TestCase
         /**
          * @var \Groups\Model\Table\GroupsTable $table
          */
-        $table = TableRegistry::get('Groups.Groups');
+        $table = TableRegistry::getTableLocator()->get('Groups.Groups');
         $this->Groups = $table;
 
         /** @var \Cake\Console\ConsoleIo */

--- a/tests/TestCase/Shell/Task/UserGroupCleanupTaskTest.php
+++ b/tests/TestCase/Shell/Task/UserGroupCleanupTaskTest.php
@@ -30,13 +30,13 @@ class UserGroupCleanupTaskTest extends TestCase
         /**
          * @var \Groups\Model\Table\GroupsTable
          */
-        $table = TableRegistry::get('Groups.Groups');
+        $table = TableRegistry::getTableLocator()->get('Groups.Groups');
         $this->Groups = $table;
 
         /**
          * @var \CakeDC\Users\Model\Table\UsersTable
          */
-        $table = TableRegistry::get('CakeDC/Users.Users');
+        $table = TableRegistry::getTableLocator()->get('CakeDC/Users.Users');
         $this->Users = $table;
 
         /** @var \Cake\Console\ConsoleIo */

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -85,6 +85,21 @@ Cake\Core\Configure::write('Session', [
     'defaults' => 'php',
 ]);
 
+Cake\Core\Plugin::getCollection()->add(new \Groups\Plugin([
+    'path' => ROOT . DS,
+    'routes' => true,
+]));
+if (file_exists(ROOT . '/config/bootstrap.php')) {
+    require ROOT . '/config/bootstrap.php';
+}
+
+Cake\Core\Plugin::getCollection()->add(new \CakeDC\Users\Plugin([
+    'routes' => true,
+]));
+if (file_exists(ROOT . '/vendor/cakedc/users/config/bootstrap.php')) {
+    require ROOT . '/vendor/cakedc/users/config/bootstrap.php';
+}
+
 // Ensure default test connection is defined
 if (!getenv('db_dsn')) {
     putenv('db_dsn=sqlite:///:memory:');
@@ -104,8 +119,4 @@ Cake\Datasource\ConnectionManager::setConfig('test', [
 
 // Alias AppController to the test App
 class_alias($pluginName . '\Test\App\Controller\AppController', 'App\Controller\AppController');
-// If plugin has routes.php/bootstrap.php then load them, otherwise don't.
-$loadPluginRoutes = file_exists(ROOT . DS . 'config' . DS . 'routes.php');
-$loadPluginBootstrap = file_exists(ROOT . DS . 'config' . DS . 'bootstrap.php');
-Cake\Core\Plugin::load($pluginName, ['path' => ROOT . DS, 'autoload' => true, 'routes' => $loadPluginRoutes, 'bootstrap' => $loadPluginBootstrap]);
-Cake\Core\Plugin::load('CakeDC/Users', ['routes' => true, 'bootstrap' => true]);
+

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -119,4 +119,3 @@ Cake\Datasource\ConnectionManager::setConfig('test', [
 
 // Alias AppController to the test App
 class_alias($pluginName . '\Test\App\Controller\AppController', 'App\Controller\AppController');
-


### PR DESCRIPTION
This PR defines v3.8 as the minimum CakePHP version acceptable and fixes most of the deprecation warnings.

